### PR TITLE
PN-14154: added control for enable/disablec redirect function on weblandigncdn stack via flag parameter/output

### DIFF
--- a/codegen/pn-infra-configurations.yaml
+++ b/codegen/pn-infra-configurations.yaml
@@ -24,6 +24,7 @@ envs:
           #Landing (pn-showcase) conf.
           pagopa_zone_delegation_enabled: false
           generate_landing_multi_domain_cdn_cert: true
+          enable_landing_cdn_redirect_function: true
           landing_cdn_allowed_internal_zones:
             - "dev.notifichedigitali.it"
           landing_cdn_allowed_external_zones:
@@ -64,6 +65,7 @@ envs:
           pn_cost_anomaly_detection_threshold: "10"
           #Landing (pn-showcase) conf.
           generate_landing_multi_domain_cdn_cert: true
+          enable_landing_cdn_redirect_function: false
           landing_cdn_allowed_internal_zones:
             - "test.notifichedigitali.it"
           landing_cdn_allowed_external_zones:
@@ -103,6 +105,7 @@ envs:
           pn_cost_anomaly_detection_threshold: "10"
           #Landing (pn-showcase) conf.
           generate_landing_multi_domain_cdn_cert: true
+          enable_landing_cdn_redirect_function: false
           landing_cdn_allowed_internal_zones:
             - "uat.notifichedigitali.it"
           landing_cdn_allowed_external_zones:
@@ -144,6 +147,7 @@ envs:
           pn_dns_extra_cname_entries: '{\"assistenza\": \"hc-send.zendesk.com\"}'
           #Landing (pn-showcase) conf.
           generate_landing_multi_domain_cdn_cert: true
+          enable_landing_cdn_redirect_function: false
           landing_cdn_allowed_internal_zones:
             - "notifichedigitali.it"
             - "notifichedigitali.pagopa.it"
@@ -183,6 +187,7 @@ envs:
           pn_cost_anomaly_detection_threshold: "10"
           #Landing (pn-showcase) conf.
           generate_landing_multi_domain_cdn_cert: true
+          enable_landing_cdn_redirect_function: false
           landing_cdn_allowed_internal_zones:
             - "hotfix.notifichedigitali.it"
           landing_cdn_allowed_external_zones:

--- a/src/main/98-variables.tf
+++ b/src/main/98-variables.tf
@@ -112,6 +112,12 @@ variable "generate_landing_multi_domain_cdn_cert" {
   default     = false
 }
 
+variable "enable_landing_cdn_redirect_function" {
+  type        = bool
+  description = "If true, enable the creation of the cloudfront fucntion for redirect in the web-landing-cdn cloudformation stack."
+  default     = false
+}
+
 variable "landing_cdn_allowed_internal_zones" {
   type        = list(string)
   description = "List of allowed internal Route53 zones for pn-showcase landing page multi domain certificate"

--- a/src/main/99-outputs.tf
+++ b/src/main/99-outputs.tf
@@ -223,10 +223,14 @@ output "Core_LandingMultiDomainCertInternalDomainsZonesMap" {
   ) : null
 }
 
-
 output "Core_LandingMultiDomainCertExternalDomainsZonesMap" {
   description = "Comma delimited list, containing map of external domains, and relative parent zone name"
   value       = var.generate_landing_multi_domain_cdn_cert ? module.landing_cdn_multi_domain_acm_cert[0].external_domains_with_zones : null
+}
+
+output "Core_EnableLandingCdnRedirectFunction" {
+  value = var.enable_landing_cdn_redirect_function ? "true" : "false"
+  description = "Flag to enable redirect function in landing CDN"
 }
 
 output "Core_PortalePgDomain" {

--- a/src/main/env/dev/terraform.tfvars
+++ b/src/main/env/dev/terraform.tfvars
@@ -15,6 +15,7 @@ pn_cost_anomaly_detection_email = "pn-irt-team@pagopa.it"
 pn_cost_anomaly_detection_threshold = "10"
 pagopa_zone_delegation_enabled = false
 generate_landing_multi_domain_cdn_cert = true
+enable_landing_cdn_redirect_function = true
 landing_cdn_allowed_internal_zones = ["dev.notifichedigitali.it"]
 landing_cdn_allowed_external_zones = ["notifichedigitali.pagopa.it"]
 landing_multi_domain_cert_domains = ["showcase.dev.notifichedigitali.it","www.dev.notifichedigitali.it","dev.notifichedigitali.pagopa.it","www.dev.notifichedigitali.pagopa.it"]

--- a/src/main/env/hotfix/terraform.tfvars
+++ b/src/main/env/hotfix/terraform.tfvars
@@ -14,6 +14,7 @@ pn_auth_fleet_addictive_allowed_issuer = "https://uat.selfcare.pagopa.it,https:/
 pn_cost_anomaly_detection_email = "pn-irt-team@pagopa.it"
 pn_cost_anomaly_detection_threshold = "10"
 generate_landing_multi_domain_cdn_cert = true
+enable_landing_cdn_redirect_function = false
 landing_cdn_allowed_internal_zones = ["hotfix.notifichedigitali.it"]
 landing_cdn_allowed_external_zones = ["notifichedigitali.pagopa.it"]
 landing_multi_domain_cert_domains = ["showcase.hotfix.notifichedigitali.it","www.hotfix.notifichedigitali.it","hotfix.notifichedigitali.pagopa.it","www.hotfix.notifichedigitali.pagopa.it"]

--- a/src/main/env/prod/terraform.tfvars
+++ b/src/main/env/prod/terraform.tfvars
@@ -15,6 +15,7 @@ pn_cost_anomaly_detection_email = "pn-irt-team@pagopa.it"
 pn_cost_anomaly_detection_threshold = "10"
 pn_dns_extra_cname_entries = "{\"assistenza\": \"hc-send.zendesk.com\"}"
 generate_landing_multi_domain_cdn_cert = true
+enable_landing_cdn_redirect_function = false
 landing_cdn_allowed_internal_zones = ["notifichedigitali.it","notifichedigitali.pagopa.it"]
 landing_multi_domain_cert_domains = ["showcase.notifichedigitali.it","www.notifichedigitali.it","notifichedigitali.pagopa.it","www.notifichedigitali.pagopa.it"]
 landing_single_domain = "www"

--- a/src/main/env/test/terraform.tfvars
+++ b/src/main/env/test/terraform.tfvars
@@ -14,6 +14,7 @@ pn_auth_fleet_addictive_allowed_issuer = "https://dev.selfcare.pagopa.it,https:/
 pn_cost_anomaly_detection_email = "pn-irt-team@pagopa.it"
 pn_cost_anomaly_detection_threshold = "10"
 generate_landing_multi_domain_cdn_cert = true
+enable_landing_cdn_redirect_function = false
 landing_cdn_allowed_internal_zones = ["test.notifichedigitali.it"]
 landing_cdn_allowed_external_zones = ["notifichedigitali.pagopa.it"]
 landing_multi_domain_cert_domains = ["showcase.test.notifichedigitali.it","www.test.notifichedigitali.it","test.notifichedigitali.pagopa.it","www.test.notifichedigitali.pagopa.it"]

--- a/src/main/env/uat/terraform.tfvars
+++ b/src/main/env/uat/terraform.tfvars
@@ -14,6 +14,7 @@ pn_auth_fleet_addictive_allowed_issuer = "https://uat.selfcare.pagopa.it,https:/
 pn_cost_anomaly_detection_email = "pn-irt-team@pagopa.it"
 pn_cost_anomaly_detection_threshold = "10"
 generate_landing_multi_domain_cdn_cert = true
+enable_landing_cdn_redirect_function = false
 landing_cdn_allowed_internal_zones = ["uat.notifichedigitali.it"]
 landing_cdn_allowed_external_zones = ["notifichedigitali.pagopa.it"]
 landing_multi_domain_cert_domains = ["showcase.uat.notifichedigitali.it","www.uat.notifichedigitali.it","uat.notifichedigitali.pagopa.it","www.uat.notifichedigitali.pagopa.it"]


### PR DESCRIPTION
In the actual state the flag variable  enable_landing_cdn_redirect_function is true only for dev env,
will be disabled in dev and enabled in prod just during the second step of the "switch to CMS release".